### PR TITLE
Feat: 로그인 axios 통신 및 토큰 상태 관리 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.6.5",
         "pinia": "^2.1.7",
+        "pinia-plugin-persistedstate": "^3.2.1",
         "vue": "^3.3.11",
         "vue-router": "^4.2.5",
         "vuetify": "^3.4.10"
@@ -907,6 +908,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pinia-plugin-persistedstate": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-3.2.1.tgz",
+      "integrity": "sha512-MK++8LRUsGF7r45PjBFES82ISnPzyO6IZx3CH5vyPseFLZCk1g2kgx6l/nW8pEBKxxd4do0P6bJw+mUSZIEZUQ==",
+      "peerDependencies": {
+        "pinia": "^2.0.0"
       }
     },
     "node_modules/pinia/node_modules/vue-demi": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^1.6.5",
     "pinia": "^2.1.7",
+    "pinia-plugin-persistedstate": "^3.2.1",
     "vue": "^3.3.11",
     "vue-router": "^4.2.5",
     "vuetify": "^3.4.10"

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,6 +1,12 @@
 <script>
+import {useAuthStore} from "@/store/AuthStore.js";
+
 export default {
-  name: "Header"
+  name: "Header",
+  setup() {
+    const authStore = useAuthStore();
+    return { authStore }
+  }
 }
 </script>
 
@@ -9,11 +15,14 @@ export default {
   <h1>Shout Link!</h1>
   <div class="d-flex align-center ga-3">
     <router-link to="/">홈</router-link>
-    <router-link to="/login">로그인</router-link>
+    <p class="clickable" @click="authStore.logout" v-if="authStore.isLogin">로그아웃</p>
+    <router-link to="/login" v-else>로그인</router-link>
   </div>
 </div>
 </template>
 
 <style scoped>
-
+.clickable:hover {
+  cursor: pointer;
+}
 </style>

--- a/src/components/login/LoginForm.vue
+++ b/src/components/login/LoginForm.vue
@@ -1,11 +1,23 @@
 <script>
+import axios from "axios";
+import {useAuthStore} from "@/store/AuthStore.js";
+
 export default {
+  setup() {
+    const authStore = useAuthStore();
+    return {authStore}
+  },
   data() {
     return {
       loginRequest: {
         email: "",
         password: "",
       }
+    }
+  },
+  methods: {
+    login() {
+      this.authStore.loginApiCall(this.loginRequest.email, this.loginRequest.password);
     }
   }
 }
@@ -24,6 +36,7 @@ export default {
         variant="solo">
     </v-text-field>
     <v-btn
+        @click="login"
         size="large"
         block>
       로그인

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,11 @@ import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import '@mdi/font/css/materialdesignicons.css'
+
+// Pinia
 import {createPinia} from "pinia";
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate';
+
 
 const vuetify = createVuetify({
   components,
@@ -21,6 +25,7 @@ axios.defaults.baseURL = 'https://shoutlink.me'
 
 //pinia
 const pinia = createPinia();
+pinia.use(piniaPluginPersistedstate);
 
 const app = createApp(App);
 app.use(router)

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import { createVuetify } from 'vuetify'
 import * as components from 'vuetify/components'
 import * as directives from 'vuetify/directives'
 import '@mdi/font/css/materialdesignicons.css'
+import {createPinia} from "pinia";
 
 const vuetify = createVuetify({
   components,
@@ -18,7 +19,11 @@ const vuetify = createVuetify({
 //axios
 axios.defaults.baseURL = 'https://shoutlink.me'
 
+//pinia
+const pinia = createPinia();
+
 const app = createApp(App);
 app.use(router)
 app.use(vuetify)
+app.use(pinia)
 app.mount('#app')

--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -1,0 +1,16 @@
+import {defineStore} from "pinia";
+
+export const useAuthStore = defineStore('auth', {
+  state: () => ({
+    accessToken: "",
+    memberId: ""
+  }),
+  getters: {
+    getBearerToken(state) {
+      return 'Bearer ' + state.accessToken;
+    },
+    getMemberId(state) {
+      return state.memberId;
+    }
+  }
+});

--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -1,4 +1,6 @@
 import {defineStore} from "pinia";
+import axios from "axios";
+import router from "@/router/router.js";
 
 export const useAuthStore = defineStore('auth', {
   state: () => ({
@@ -11,6 +13,29 @@ export const useAuthStore = defineStore('auth', {
     },
     getMemberId(state) {
       return state.memberId;
+    }
+  },
+  actions: {
+    loginApiCall(email, password) {
+      axios.post('/api/login', {
+        email: email,
+        password: password,
+      })
+      .then((response) => {
+        const data = response.data;
+        this.accessToken = data.accessToken;
+        this.memberId = data.memberId;
+        router.replace('/');
+      })
+      .catch((error) => {
+        const response = error.response.data;
+        const errorCode = response.errorCode;
+        switch (errorCode) {
+          case 'SL101':
+            alert('이메일/비밀번호가 일치하지 않습니다!');
+            break;
+        }
+      })
     }
   }
 });

--- a/src/store/AuthStore.js
+++ b/src/store/AuthStore.js
@@ -5,7 +5,7 @@ import router from "@/router/router.js";
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     accessToken: "",
-    memberId: ""
+    memberId: 0
   }),
   getters: {
     getBearerToken(state) {
@@ -13,6 +13,9 @@ export const useAuthStore = defineStore('auth', {
     },
     getMemberId(state) {
       return state.memberId;
+    },
+    isLogin(state) {
+      return state.accessToken.length !== 0;
     }
   },
   actions: {
@@ -36,6 +39,11 @@ export const useAuthStore = defineStore('auth', {
             break;
         }
       })
+    },
+    logout() {
+      this.accessToken = "";
+      this.memberId = 0;
     }
-  }
+  },
+  persist: true
 });


### PR DESCRIPTION
## 작업 내용

- 사용자 인증 정보 유지를 위한 AuthStore 구현
- 새로고침 시 pinia 상태 정보가 초기화되는 것을 방지하기 위해 `pinia-plugin-persistedstate` 의존성 추가
- 사용자 로그인 여부에 따라 헤더의 로그인/로그아웃 변경 추가