### PR TITLE
Feat: 도메인 보기 추가

### DIFF
--- a/src/components/home/LinkSection.vue
+++ b/src/components/home/LinkSection.vue
@@ -57,6 +57,15 @@ export default {
     },
     changeShowUrl() {
       this.showUrl = !this.showUrl;
+    },
+    removePathFromUrl(url) {
+      if(url.startsWith("http://") || url.startsWith("https://")) {
+        url = new URL(url).host;
+      } else {
+        const firstIndexOfSlash = url.indexOf("/");
+        url = url.substring(0, firstIndexOfSlash);
+      }
+      return url;
     }
   }
 }
@@ -77,8 +86,8 @@ export default {
           <v-card-title>
             {{ n.description }}
           </v-card-title>
-          <v-card-subtitle v-if="showUrl">
-            {{ n.url }}
+          <v-card-subtitle>
+            {{ showUrl ? n.url : removePathFromUrl(n.url) }}
           </v-card-subtitle>
         </v-card-item>
       </v-card>

--- a/src/components/hub/hublink/HubLinkSection.vue
+++ b/src/components/hub/hublink/HubLinkSection.vue
@@ -66,6 +66,15 @@ export default {
     },
     changeShowUrl() {
       this.showUrl = !this.showUrl;
+    },
+    removePathFromUrl(url) {
+      if(url.startsWith("http://") || url.startsWith("https://")) {
+        url = new URL(url).host;
+      } else {
+        const firstIndexOfSlash = url.indexOf("/");
+        url = url.substring(0, firstIndexOfSlash);
+      }
+      return url;
     }
   }
 }
@@ -89,8 +98,8 @@ export default {
           <v-card-title>
             {{ n.description }}
           </v-card-title>
-          <v-card-subtitle v-if="showUrl">
-            {{ n.url }}
+          <v-card-subtitle>
+            {{ showUrl ? n.url : removePathFromUrl(n.url) }}
           </v-card-subtitle>
         </v-card-item>
       </v-card>


### PR DESCRIPTION
## 작업 내용

- 기존 URL 보기가 선택되지 않은 경우 연결된 링크 주소 자체를 완전히 숨기던 것에서 서브 도메인을 포함한 도메인을 보여주는 것으로 변경하였습니다.